### PR TITLE
fix: resolve ambiguous PushAttribute call on macOS ARM64

### DIFF
--- a/src/kernel/search_log.tcc
+++ b/src/kernel/search_log.tcc
@@ -224,7 +224,7 @@ template<Individual I, Fitness F> void search_log::save_summary(
         for (const auto &e : stats.elite_runs(perc))
         {
           xml_closer run_summary_e(doc, "run");
-          doc.PushAttribute("id", e.run);
+          doc.PushAttribute("id", static_cast<uint64_t>(e.run));
 
           if (e.best_measurements.fitness)
             set_text(doc, "fitness", *e.best_measurements.fitness);

--- a/src/kernel/search_log.tcc
+++ b/src/kernel/search_log.tcc
@@ -224,7 +224,7 @@ template<Individual I, Fitness F> void search_log::save_summary(
         for (const auto &e : stats.elite_runs(perc))
         {
           xml_closer run_summary_e(doc, "run");
-          doc.PushAttribute("id", static_cast<uint64_t>(e.run));
+          doc.PushAttribute("id", static_cast<std::uint64_t>(e.run));
 
           if (e.best_measurements.fitness)
             set_text(doc, "fitness", *e.best_measurements.fitness);


### PR DESCRIPTION
## Summary
- Cast `std::size_t` to `uint64_t` in `search_log.tcc:227` to resolve an ambiguous `PushAttribute` overload when building with Apple Clang 17 on macOS ARM64

## Details
`std::size_t` is `unsigned long` on this platform, which doesn't match any tinyxml2 `PushAttribute` overload exactly, causing a compile error. The explicit cast to `uint64_t` resolves the ambiguity.

## Test plan
- [x] Verify `cmake --build build` completes without the ambiguous call error on macOS ARM64